### PR TITLE
Add stub Tandy 1000 EX driver and build script

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,41 +1,42 @@
-# OEMDisplay-Tandy  
-*Windows 3.x OEM Display Driver for the Tandy 1000 Series*  
+# OEMDisplay-Tandy
+*Windows 3.x OEM Display Driver for the Tandy 1000 Series*
 
-![Tandy 1000 Logo](docs/images/tandy-logo.png)  
-![Windows 3.x Logo](docs/images/win3x-logo.png)  
-
----
-
-## 📖 Overview  
-This project provides a **Windows 3.x display driver** for the **Tandy 1000 series** of computers, enabling proper use of the **Tandy Graphics Adapter (TGA)** 320×200 16-color mode.  
-
-By default, Windows 3.0/3.1 only offers **CGA (2 colors)** or **EGA (limited support)** on Tandy hardware. This driver restores the full visual potential of the platform, giving your Tandy 1000 a native Windows 3.x experience.  
+![Tandy 1000 Logo](docs/images/tandy-logo.png)
+![Windows 3.x Logo](docs/images/win3x-logo.png)
 
 ---
 
-## ✨ Features  
-- Support for **320×200 16-color TGA mode**  
-- Correct palette handling and mode switching  
-- Compatible with **Windows 3.0** and **Windows 3.1** (Standard & Real Mode)  
-- Built with **Microsoft C 6.0** and **MASM 5.1** using the official **Windows 3.x DDK**  
+## 📖 Overview
+This project provides a **Windows 3.x display driver** for the **Tandy 1000 series** of computers, enabling proper use of the **Tandy Graphics Adapter (TGA)** 320×200 16-color mode.
+
+By default, Windows 3.0/3.1 only offers **CGA (2 colors)** or **EGA (limited support)** on Tandy hardware. This driver restores the full visual potential of the platform, giving your Tandy 1000 a native Windows 3.x experience.
 
 ---
 
-## 🖥️ Requirements  
-- Tandy 1000 series system (EX, HX, TX, RL, or compatible)  
-- MS-DOS 3.2+  
-- Windows 3.0 or 3.1 (Real or Standard Mode)  
-- Development system (for building):  
-  - 386 or better  
-  - Microsoft C 6.0  
-  - Microsoft Macro Assembler 5.1  
-  - Windows 3.x DDK  
+## ✨ Features
+- Support for **320×200 16-color TGA mode**
+- Correct palette handling and mode switching
+- Compatible with **Windows 3.0** and **Windows 3.1** (Standard & Real Mode)
+- Built with **Microsoft C 6.0** and **MASM 5.1** using the official **Windows 3.x DDK**
 
 ---
 
-## 🔧 Building  
-1. Install Microsoft C 6.0 and MASM 5.1 on your development VM (DOS 6.22 + Windows 3.1 recommended).  
-2. Clone this repository or transfer the source to your VM.  
-3. From the DOS prompt, run:  
+## 🖥️ Requirements
+- Tandy 1000 series system (EX, HX, TX, RL, or compatible)
+- MS-DOS 3.2+
+- Windows 3.0 or 3.1 (Real or Standard Mode)
+- Development system (for building):
+  - 386 or better
+  - Microsoft C 6.0
+  - Microsoft Macro Assembler 5.1
+  - Windows 3.x DDK
+
+---
+
+## 🔧 Building
+1. Install Microsoft C 6.0 and MASM 5.1 on your development VM (DOS 6.22 + Windows 3.1 recommended).
+2. Clone this repository or transfer the source to your VM.
+3. From the DOS prompt, run:
    ```sh
    nmake tandy16.mak
+   ```

--- a/src/tandy16.c
+++ b/src/tandy16.c
@@ -1,0 +1,18 @@
+#include "tandy16.h"
+
+/* Stub implementation for Tandy 1000 EX Windows 3.x display driver */
+
+int far pascal LibMain(unsigned int hInstance,
+                       unsigned short wDataSegment,
+                       unsigned short wHeapSize,
+                       char far* lpszCmdLine)
+{
+    /* Placeholder for driver initialization */
+    return 1; /* success */
+}
+
+int far pascal WEP(int bSystemExit)
+{
+    /* Windows Exit Procedure */
+    return 1;
+}

--- a/src/tandy16.h
+++ b/src/tandy16.h
@@ -1,0 +1,13 @@
+#ifndef TANDY16_H
+#define TANDY16_H
+
+/* Stub header for Tandy 1000 EX Windows 3.x display driver */
+
+int far pascal LibMain(unsigned int hInstance,
+                       unsigned short wDataSegment,
+                       unsigned short wHeapSize,
+                       char far* lpszCmdLine);
+
+int far pascal WEP(int bSystemExit);
+
+#endif /* TANDY16_H */

--- a/tandy16.mak
+++ b/tandy16.mak
@@ -1,0 +1,15 @@
+# NMAKE makefile for the Tandy 1000 EX display driver stub
+# Build with: nmake tandy16.mak
+
+CC = cl
+CFLAGS = /c /W3
+OBJS = tandy16.obj
+
+all: $(OBJS)
+
+# Compile the driver
+$(OBJS): src\\tandy16.c src\\tandy16.h
+	$(CC) $(CFLAGS) src\\tandy16.c
+
+clean:
+	del $(OBJS)


### PR DESCRIPTION
## Summary
- Add initial `tandy16.c` and `tandy16.h` for a minimal Windows 3.x Tandy driver
- Provide `tandy16.mak` NMAKE file for building with Microsoft C
- Update README building instructions

## Testing
- `nmake tandy16.mak` *(fails: command not found)*
- `make -f tandy16.mak` *(fails: No rule to make target)*

------
https://chatgpt.com/codex/tasks/task_e_68b340fbba7083258b996f1adabd224a