### PR TITLE
Expand makefile to build new driver components

### DIFF
--- a/tandy16.mak
+++ b/tandy16.mak
@@ -3,13 +3,17 @@
 
 CC = cl
 CFLAGS = /c /W3
-OBJS = tandy16.obj
+OBJS = enable.obj tga_video.obj
 
 all: $(OBJS)
 
 # Compile the driver
-$(OBJS): src\\tandy16.c src\\tandy16.h
-	$(CC) $(CFLAGS) src\\tandy16.c
+enable.obj: src\\enable.c src\\tndy16.h
+	$(CC) $(CFLAGS) src\\enable.c
+
+tga_video.obj: src\\tga_video.asm
+	ml /c /Fo tga_video.obj src\\tga_video.asm
 
 clean:
-	del $(OBJS)
+	del enable.obj
+	del tga_video.obj


### PR DESCRIPTION
## Summary
- Build `enable.obj` and `tga_video.obj` via updated OBJS list
- Compile `enable.c` and assemble `tga_video.asm`
- Clean both object files

## Testing
- `make -f tandy16.mak` *(fails: No rule to make target 'src\\enable.c', needed by 'enable.obj')*


------
https://chatgpt.com/codex/tasks/task_e_68b384d428508325914459301111d76b