### PR TITLE
Fix GlobalHandle cast in free_shadow

### DIFF
--- a/src/enable.c
+++ b/src/enable.c
@@ -51,7 +51,7 @@ static int near alloc_shadow(void) {
 
 static void near free_shadow(void) {
     if (g_tndy.shadow) {
-        HGLOBAL h = GlobalHandle( (LPCVOID)g_tndy.shadow );
+        HGLOBAL h = GlobalHandle(g_tndy.shadow);
         GlobalUnlock(h);
         GlobalFree(h);
         g_tndy.shadow = NULL;


### PR DESCRIPTION
## Summary
- simplify GlobalHandle usage in `free_shadow`

## Testing
- `make -f tndy16.mak` *(fails: No rule to make target 'src\\enable.c', needed by 'enable.obj')*
- `nmake tndy16.mak` *(fails: command not found)*
- `gcc -c src/enable.c -o /tmp/enable.o` *(fails: windows.h: No such file or directory)*

------
https://chatgpt.com/codex/tasks/task_e_68b5dab72760832591ae01a5ad6460d7