### PR TITLE
Fix GlobalHandle pointer type

### DIFF
--- a/src/enable.c
+++ b/src/enable.c
@@ -4,7 +4,7 @@
  * External module tga_video.asm provides the real hardware work.
  */
 
-#include <windows.h>
+#include "windows.h"
 #include <string.h>
 /* #include <gdidefs.h> */
 #include "tgavid.h"
@@ -121,9 +121,10 @@ int FAR PASCAL Enable(LPDEVICE lpDevice)
     return 1; /* success */
 }
 
-void FAR PASCAL Disable(void)
+void FAR PASCAL Disable(LPDEVICE lpDevice)
 {
     /* Free resources and restore text mode */
+    (void)lpDevice;
     free_shadow();
     TGA_SetTextMode();
 }

--- a/src/windows.h
+++ b/src/windows.h
@@ -219,6 +219,7 @@ typedef DWORD NEAR*         PDWORD;
 typedef DWORD FAR*          LPDWORD;
 
 typedef void FAR*           LPVOID;
+typedef const void FAR*     LPCVOID;
 
 #define MAKELP(sel, off)    ((void FAR*)MAKELONG((off), (sel)))
 #define SELECTOROF(lp)      HIWORD(lp)
@@ -684,7 +685,7 @@ char FAR* WINAPI GlobalLock(HGLOBAL);
 BOOL    WINAPI GlobalUnlock(HGLOBAL);
 
 DWORD   WINAPI GlobalSize(HGLOBAL);
-DWORD   WINAPI GlobalHandle(UINT);
+HGLOBAL WINAPI GlobalHandle(LPCVOID);
 
 /* GlobalFlags return flags (in addition to GMEM_DISCARDABLE) */
 #define GMEM_DISCARDED	    0x4000


### PR DESCRIPTION
## Summary
- include local windows.h so Win16 pointer types like LPCVOID are available
- match Disable function definition to its prototype

## Testing
- `make -f tndy16.mak` *(fails: No rule to make target 'src\\enable.c', needed by 'enable.obj')*


------
https://chatgpt.com/codex/tasks/task_e_68b5e2bded2483258998e68a09c87bff