### PR TITLE
Use MASM verbose model options

### DIFF
--- a/tndy16.mak
+++ b/tndy16.mak
@@ -5,6 +5,7 @@ CC = cl
 ML = masm
 
 CFLAGS = /c /W3
+MASMFLAGS = -v -ML -I.\\
 OBJS = enable.obj tgavid.obj
 
 all: $(OBJS)
@@ -14,7 +15,7 @@ enable.obj: src\\enable.c src\\tndy16.h
 	$(CC) $(CFLAGS) src\\enable.c
 
 tgavid.obj: src\\tgavid.asm
-	$(ML) /c tgavid.obj , src\\tgavid.asm
+        $(ML) $(MASMFLAGS) src\\tgavid.asm, tgavid.obj;
 
 clean:
 	del enable.obj


### PR DESCRIPTION
## Summary
- add MASMFLAGS to tndy16.mak for verbose model build
- invoke MASM with -v -ML -I. and proper source/object ordering

## Testing
- `nmake tndy16.mak` *(fails: command not found)*
- `make -f tndy16.mak` *(fails: missing separator due to NMAKE syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f338bcbc8325a1728d526255912d