### PR TITLE
Fix MASM warnings in TGA_GetPlaneInfo

### DIFF
--- a/src/TGAVID.ASM
+++ b/src/TGAVID.ASM
@@ -97,22 +97,22 @@ TGA_SetTextMode PROC FAR
     ret
 TGA_SetTextMode ENDP
 
-; --- void TGA_GetPlaneInfo(TGAPlaneInfo far *out) ---
+; --- void TGA_GetPlaneInfo(TGAPlaneInfo far *info) ---
 PUBLIC TGA_GetPlaneInfo
-TGA_GetPlaneInfo PROC FAR out:DWORD
+TGA_GetPlaneInfo PROC FAR info:DWORD
     push ds
     push si
     push di
 
     ; DS:SI -> _planeInfo
-    ; ES:DI -> out
+    ; ES:DI -> caller buffer ("info")
     push ds
-    pop  es                  ; ES = DS (we’ll set DS to DGROUP)
-    mov  ax, @DATA
+    pop  es                  ; ES = DS (we’ll set DS to data segment)
+    mov  ax, SEG _pi_vramSeg
     mov  ds, ax
 
     lea  si, _pi_vramSeg
-    les  di, out             ; far *out in stack
+    les  di, info            ; far *info in stack
     ; copy struct: 2 + (4*2) + 2 + 1 = 13 bytes (round to 14)
     mov  cx, 7               ; copy 7 words = 14 bytes (over-copies 1 pad byte, OK)
 copy_words:


### PR DESCRIPTION
## Summary
- Rename parameter to avoid using reserved word `out`
- Load data segment using `SEG _pi_vramSeg` instead of undefined `@DATA`

## Testing
- `make -f tndy16.mak` *(fails: missing separator / unsupported NMAKE syntax)*

------
https://chatgpt.com/codex/tasks/task_e_68b5f928a28c8325bb30bda8ff703c85