### PR TITLE
Add OEM setup INF and update documentation

### DIFF
--- a/FILE_ID.DIZ
+++ b/FILE_ID.DIZ
@@ -6,4 +6,4 @@ Build with MS C 6.0 & MASM 5.1
 Includes source and makefile
 Requires MS-DOS 3.2+ & Win 3.x
 NMAKE TANDY16.MAK to build
-MIT-licensed open source project
+GPL-licensed open source project

--- a/README.TXT
+++ b/README.TXT
@@ -27,4 +27,4 @@ Building
 
 License
 -------
-This project is released under the MIT License. See LICENSE for details.
+This project is released under the GNU General Public License v3.0. See LICENSE for details.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,6 @@
 # OEMDisplay-Tandy
 *Windows 3.x OEM Display Driver for the Tandy 1000 Series*
 
-![Tandy 1000 Logo](docs/images/tandy-logo.png)
-![Windows 3.x Logo](docs/images/win3x-logo.png)
-
 ---
 
 ## 📖 Overview
@@ -18,6 +15,9 @@ By default, Windows 3.0/3.1 only offers **CGA (2 colors)** or **EGA (limited sup
 - Correct palette handling and mode switching
 - Compatible with **Windows 3.0** and **Windows 3.1** (Standard & Real Mode)
 - Built with **Microsoft C 6.0** and **MASM 5.1** using the official **Windows 3.x DDK**
+
+## 🚧 Project Status
+This driver is under active development and may not yet be fully functional. Testing and contributions from the community are highly appreciated—please open issues or pull requests if you'd like to help.
 
 ---
 
@@ -40,3 +40,11 @@ By default, Windows 3.0/3.1 only offers **CGA (2 colors)** or **EGA (limited sup
    ```sh
    nmake tandy16.mak
    ```
+
+---
+
+## 🤝 Contributing
+We welcome community contributions! If you encounter problems or have ideas for improvements, feel free to open an issue or submit a pull request.
+
+## 📜 License
+This project is released under the [GNU General Public License v3.0](LICENSE).

--- a/oemsetup.inf
+++ b/oemsetup.inf
@@ -1,0 +1,11 @@
+; OEMSETUP.INF for the Tandy 1000 Windows 3.x display driver
+
+[disks]
+1="Tandy 1000 Display Driver Disk",,0
+
+[files]
+tndy16.drv,tndy16.drv,1
+
+[setup]
+display.drv,tndy16.drv
+


### PR DESCRIPTION
## Summary
- add `oemsetup.inf` for installing the Tandy 1000 Windows 3.x display driver
- clean up README to remove broken images, note development status, and invite contributions
- switch distribution docs to GNU GPL v3 licensing

## Testing
- `nmake tndy16.mak` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b73381fc3483258db094b8090b9053