### PR TITLE
Use LibEntry startup for driver link

### DIFF
--- a/mkdrv.bat
+++ b/mkdrv.bat
@@ -1,2 +1,3 @@
 rem Link the Tandy 16-color driver using Windows 3.0 libraries
-link enable.obj tgavid.obj, tndy16.drv,, libw slibcew gdi kernel user, tndy16.def 
+rem Include LIBENTRY to route startup through LibMain/WEP instead of WinMain
+link libentry.obj enable.obj tgavid.obj, tndy16.drv,, libw slibcew gdi kernel user, tndy16.def


### PR DESCRIPTION
## Summary
- link driver via LIBENTRY to avoid unresolved WinMain and use LibMain/WEP startup

## Testing
- `bash BUILD.BAT` *(fails: nmake: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b90368571883259842144ae16d6970