### PR TITLE
Add DLL entry stubs

### DIFF
--- a/mkdrv.bat
+++ b/mkdrv.bat
@@ -1,3 +1,3 @@
 rem Link the Tandy 16-color driver using Windows 3.0 libraries
 rem Include LIBENTRY to route startup through LibMain/WEP instead of WinMain
-link libentry.obj enable.obj tgavid.obj, tndy16.drv,, libw slibcew gdi kernel user, tndy16.def
+link libentry.obj dllentry.obj enable.obj tgavid.obj, tndy16.drv,, libw slibcew gdi kernel user, tndy16.def

--- a/src/dllentry.c
+++ b/src/dllentry.c
@@ -1,0 +1,22 @@
+#include "windows.h"
+
+/*
+ * DLL entry points for the Tandy 16-color display driver.
+ * LibMain is invoked by the loader at attach time, and WEP is called
+ * on detach.  The driver performs all work through the exported
+ * Enable/Disable routines so these just report success.
+ */
+int FAR PASCAL LibMain(HINSTANCE hInst, WORD wDataSeg, WORD cbHeap, LPSTR lpCmdLine)
+{
+    (void)hInst;
+    (void)wDataSeg;
+    (void)cbHeap;
+    (void)lpCmdLine;
+    return 1;
+}
+
+int FAR PASCAL _loadds WEP(int nParam)
+{
+    (void)nParam;
+    return 1;
+}

--- a/tndy16.mak
+++ b/tndy16.mak
@@ -6,17 +6,21 @@ ML = masm
 
 CFLAGS = /c /W3
 MASMFLAGS = -v -ML -I.\\
-OBJS = enable.obj tgavid.obj
+OBJS = dllentry.obj enable.obj tgavid.obj
 
 all: $(OBJS)
 
 # Compile the driver
+dllentry.obj: src\\dllentry.c
+	$(CC) $(CFLAGS) src\\dllentry.c
+
 enable.obj: src\\enable.c src\\tndy16.h
 	$(CC) $(CFLAGS) src\\enable.c
 
 tgavid.obj: src\\tgavid.asm
-        $(ML) $(MASMFLAGS) src\\tgavid.asm, tgavid.obj;
+	$(ML) $(MASMFLAGS) src\\tgavid.asm, tgavid.obj;
 
 clean:
+	del dllentry.obj
 	del enable.obj
 	del tgavid.obj


### PR DESCRIPTION
## Summary
- provide LibMain and WEP implementations for the driver
- include DLL entry module in makefile and link script

## Testing
- `make -f tndy16.mak` *(fails: No rule to make target 'src\\dllentry.c', needed by 'dllentry.obj')*

------
https://chatgpt.com/codex/tasks/task_e_68b61f3df9e88325bf28d0c664a22f75