### PR TITLE
Complete OEMSETUP.INF for Tandy 1000 driver

### DIFF
--- a/oemsetup.inf
+++ b/oemsetup.inf
@@ -32,8 +32,15 @@
 ;profile = driver,         Description of driver,                           resolution,    286 grabber,    logo code,       VDD,            386grabber,   ega.sys,   logo data
 ;hercules = b:hercules.drv, "Hercules Monochrome",                           "133,96,72",   b:hercules.2gr, a:herclogo.lgo,  b:vddherc.386,  b:herc.3gr,,             a:herclogo.rle
 
+; Tandy 1000 320x200 16-color TGA mode
+tndy16 = 1:tndy16.drv, "Tandy 1000 320x200 16 colors", "320,200,16", 1:tndy16.2gr,, 1:vddvga.386, 1:tndy16.3gr,,
+
 [files]
 tndy16.drv,tndy16.drv,1
+
+tndy16.2gr,tndy16.2gr,1
+tndy16.3gr,tndy16.3gr,1
+vddvga.386,vddvga.386,1
 
 ; 386 GRABBER FONTS
 ; ---------------------------------------------------------------
@@ -43,8 +50,8 @@ tndy16.drv,tndy16.drv,1
 ; your grabber name.  You only need sections that correspond to
 ; 386 grabber names in the [display] section.
 
-;[HERC.3gr]
-;1:HERCWOA.FON,b:HERC850.FON
+[TNDY16.3gr]
+1:CGA40WOA.FON,1:CGA40850.FON
 
 ; SYSTEM FONTS
 ; ---------------------------------------------------------------
@@ -52,6 +59,8 @@ tndy16.drv,tndy16.drv,1
 ; Your OEMSETUP.INF file must have these sections, with all font resolution lines
 ; appropriate for the listings in the [display] section.
 
+[TNDY16.DRV]
+320,200,16,1:VGASYS.FON,1:VGAFIX.FON,1:VGAOEM.FON
 
 [setup]
 display.drv,tndy16.drv


### PR DESCRIPTION
## Summary
- add Tandy 1000 display profile to OEMSETUP.INF
- list required driver, grabber, and VDD files
- include 386 grabber and system font mappings

## Testing
- `make -f tndy16.mak` *(fails: No rule to make target 'src\\dllentry.c')*

------
https://chatgpt.com/codex/tasks/task_e_68b924eac4f883259c63941472c433af