### PR TITLE
Remove PSGTEST reference from testing docs

### DIFF
--- a/BUILDING.MD
+++ b/BUILDING.MD
@@ -1,0 +1,17 @@
+# Building OEMDisplay-Tandy
+
+## Building
+
+1. Mount this repository as drive `C:` inside DOSBox-X.
+2. Configure the Microsoft C 6.0 environment:
+   ```
+   SET PATH=C:\BIN;%PATH%
+   SET LIB=C:\LIB
+   SET INCLUDE=C:\INCLUDE
+   ```
+3. Run `BUILD` to compile the driver.
+
+## Testing
+
+1. Copy the resulting `TNDY16.DRV` into a Windows 3.x installation.
+2. Select the driver through Windows Setup and confirm that the display initializes correctly.


### PR DESCRIPTION
## Summary
- add BUILDING.MD with DOSBox-X build steps
- update testing workflow to install the built driver in Windows 3.x instead of running PSGTEST

## Testing
- `dosbox-x -c "MOUNT C /workspace/oemdisplay-tandy" -c "C:" -c "SET PATH=C:\BIN;%PATH%" -c "SET LIB=C:\LIB" -c "SET INCLUDE=C:\INCLUDE" -c "IF EXIST TNDY16.DRV DEL TNDY16.DRV" -c "IF EXIST SRC\*.OBJ DEL SRC\*.OBJ" -c "CALL BUILD" -c "PSGTEST" -c "EXIT"` *(fails: Bad command or filename - "nmake")*

------
https://chatgpt.com/codex/tasks/task_e_68bf7aadf3e48325afb8733d81bff7c0