### PR TITLE
Remove PSGTEST reference from AGENTS instructions

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,7 +6,7 @@ Set DOS toolchain paths. Within DOSBox-X, set PATH, LIB, and INCLUDE variables t
 
 Maintain DOS-friendly files. Use unix2dos to preserve CRLF line endings, keep filenames in 8.3 uppercase form, and delete any .EXE, .OBJ, or .TXT artifacts before committing
 
-Run a clean build and test. From a DOSBox-X session, delete old binaries, invoke build, then run the executable to verify the expected output
+Run a clean build and test. From a DOSBox-X session, delete old binaries, invoke build, then install the driver in Windows 3.x to confirm it loads
 
 # Critical build constraints
 - Build with Microsoft C 6.0 or 7.0 targeting 16-bit real-mode.


### PR DESCRIPTION
## Summary
- Update root AGENTS instructions to test the built driver by installing it in Windows 3.x instead of running `psgtest`

## Testing
- `rg -n "psgtest"`
- `dosbox-x -fastlaunch -exit -c "MOUNT C ." -c "C:" -c "SET PATH=C:\\BIN;C:\\DOS" -c "SET LIB=C:\\LIB" -c "SET INCLUDE=C:\\INCLUDE" -c "IF EXIST *.OBJ DEL *.OBJ" -c "IF EXIST *.EXE DEL *.EXE" -c "IF EXIST BUILD.LOG DEL BUILD.LOG" -c "IF EXIST TNDY16.DRV DEL TNDY16.DRV" -c "BUILD" -c "TYPE BUILD.LOG" -c "DEL BUILD.LOG" -c "IF EXIST *.OBJ DEL *.OBJ" -c "IF EXIST *.EXE DEL *.EXE" -c "IF EXIST TNDY16.DRV DEL TNDY16.DRV" -c "EXIT"

------
https://chatgpt.com/codex/tasks/task_e_68bf894955e08325808081f0b4e43807