### PR TITLE
Clarify dos2unix package usage

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -4,7 +4,7 @@ Work inside DOSBox-X. Mount the repository in DOSBox-X and run the build script 
 
 Set DOS toolchain paths. Within DOSBox-X, set PATH, LIB, and INCLUDE variables to point at the bundled MS C 6.0 directories before compiling
 
-Maintain DOS-friendly files. Use unix2dos to preserve CRLF line endings, keep filenames in 8.3 uppercase form, and delete any .EXE, .OBJ, or .TXT artifacts before committing
+Maintain DOS-friendly files. Use `dos2unix`/`unix2dos` from the `dos2unix` package to preserve CRLF line endings, keep filenames in 8.3 uppercase form, and delete any .EXE, .OBJ, or .TXT artifacts before committing
 
 Run a clean build and test. From a DOSBox-X session, delete old binaries, invoke build, then install the driver in Windows 3.x to confirm it loads
 


### PR DESCRIPTION
## Summary
- Clarify that `dos2unix` provides both `dos2unix` and `unix2dos` utilities for preserving CRLF line endings.

## Testing
- `dosbox-x -exit -c "mount c /workspace/oemdisplay-tandy" -c "c:" -c "set PATH=C:\\BIN;C:\\DDK\\286\\TOOLS;C:\\DOS" -c "set LIB=C:\\LIB;C:\\DDK\\286\\LIB" -c "set INCLUDE=C:\\INCLUDE;C:\\DDK\\286\\INC" -c "nmake tndy16.mak clean" -c "build" -c "psgtest" -c "exit" >/tmp/dosbox.log 2>&1 && tail -n 20 /tmp/dosbox.log`
  - Built objects (`DLLENTRY.OBJ`, `ENABLE.OBJ`, `TGAVID.OBJ`) but `psgtest` command was not found.

------
https://chatgpt.com/codex/tasks/task_e_68bf8ebcdb9483259b033610e5ef1f93