### PR TITLE
Add release workflow for tagged builds

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -28,6 +28,7 @@ jobs:
             -c "del BUILD.LOG" \
             -c "del *.OBJ" \
             -c "del *.EXE" \
+            -c "del *.TXT" \
             -c "rd /s /q TNDY16" \
             -c "exit"
 

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,51 @@
+name: Create release
+
+on:
+  push:
+    tags:
+      - 'v*'
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install tools
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y apt-utils dosbox-x file dos2unix
+
+      - name: Build package
+        run: |
+          dosbox-x -set "dos private area=false" \
+            -c "mount c $GITHUB_WORKSPACE" \
+            -c "c:" \
+            -c "set PATH=C:\\DDK\\286\\TOOLS;C:\\BIN;%PATH%" \
+            -c "set LIB=C:\\LIB" \
+            -c "set INCLUDE=C:\\INCLUDE;C:\\DDK\\286\\INC" \
+            -c "MAKEDISK.BAT" \
+            -c "del BUILD.LOG" \
+            -c "del *.OBJ" \
+            -c "del *.EXE" \
+            -c "rd /s /q TNDY16" \
+            -c "exit"
+
+      - name: Create release
+        id: create_release
+        uses: actions/create-release@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          tag_name: ${{ github.ref }}
+          release_name: ${{ github.ref }}
+
+      - name: Upload asset
+        uses: actions/upload-release-asset@v1
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        with:
+          upload_url: ${{ steps.create_release.outputs.upload_url }}
+          asset_path: TNDY16.ZIP
+          asset_name: TNDY16.ZIP
+          asset_content_type: application/zip


### PR DESCRIPTION
## Summary
- add workflow to build driver in DOSBox-X and publish tagged releases

## Testing
- `dosbox-x -set "dos private area=false" -c "mount c ." -c "c:" -c "set PATH=C:\DDK\286\TOOLS;C:\BIN;%PATH%" -c "set LIB=C:\LIB" -c "set INCLUDE=C:\INCLUDE;C:\DDK\286\INC" -c "MAKEDISK.BAT" -c "del BUILD.LOG" -c "del *.OBJ" -c "del *.EXE" -c "rd /s /q TNDY16" -c "exit"` *(fails: build script could not locate required tools)*

------
https://chatgpt.com/codex/tasks/task_e_68bf945e2f7c83259631b76a3ef4e66e