### PR TITLE
Integrate driver link step into makefile

### DIFF
--- a/mkdrv.bat
+++ b/mkdrv.bat
@@ -1,3 +1,0 @@
-rem Link the Tandy 16-color driver using Windows 3.0 libraries
-rem Include LIBENTRY to route startup through LibMain/WEP instead of WinMain
-link dllentry.obj enable.obj tgavid.obj, tndy16.drv,, libw sdllcew gdi kernel user, tndy16.def

--- a/tndy16.mak
+++ b/tndy16.mak
@@ -8,7 +8,7 @@ CFLAGS = /c /W3
 MASMFLAGS = -v -ML -I.\\
 OBJS = dllentry.obj enable.obj tgavid.obj
 
-all: $(OBJS)
+all: TNDY16.DRV
 
 # Compile the driver
 dllentry.obj: src\\dllentry.c
@@ -18,9 +18,13 @@ enable.obj: src\\enable.c src\\tndy16.h
 	$(CC) $(CFLAGS) src\\enable.c
 
 tgavid.obj: src\\tgavid.asm
-	$(ML) $(MASMFLAGS) src\\tgavid.asm, tgavid.obj;
+        $(ML) $(MASMFLAGS) src\\tgavid.asm, tgavid.obj;
+
+TNDY16.DRV: $(OBJS) TNDY16.DEF
+        link dllentry.obj enable.obj tgavid.obj, TNDY16.DRV,, libw sdllcew gdi kernel user, TNDY16.DEF
 
 clean:
-	del dllentry.obj
-	del enable.obj
-	del tgavid.obj
+        del dllentry.obj
+        del enable.obj
+        del tgavid.obj
+        del tndy16.drv


### PR DESCRIPTION
## Summary
- Link driver objects into TNDY16.DRV directly from `tndy16.mak`
- Remove obsolete `mkdrv.bat` after integrating its functionality

## Testing
- `dosbox-x -fastlaunch -exit -c "mount c /workspace/oemdisplay-tandy" -c "c:" -c "nmake tndy16.mak"` *(fails: could not verify build output in this environment)*

------
https://chatgpt.com/codex/tasks/task_e_68bfabda42e08325b9bd3cd55f50e5fe