### PR TITLE
Add include path and header deps to build

### DIFF
--- a/tndy16.mak
+++ b/tndy16.mak
@@ -4,17 +4,18 @@
 CC = cl
 ML = masm
 
-CFLAGS = /c /W3
+CFLAGS = /c /W3 /Isrc
 MASMFLAGS = -v -ML -I.\\ -Isrc\\
 OBJS = dllentry.obj enable.obj tgavid.obj
 
 all: TNDY16.DRV
 
 # Compile the driver
-dllentry.obj: src\\dllentry.c
+dllentry.obj: src\dllentry.c src\windows.h
 	$(CC) $(CFLAGS) src\\dllentry.c
 
-enable.obj: src\\enable.c src\\tndy16.h src\\string.h src\\compat.h
+enable.obj: src\enable.c src\windows.h src\tgavid.h src\tndy16.h \
+            src\string.h src\compat.h src\stdint.h src\stdbool.h
 	$(CC) $(CFLAGS) src\\enable.c
 
 tgavid.obj: src\\tgavid.asm src\\WINDOWS.INC


### PR DESCRIPTION
## Summary
- Include `src` directory in C compiler flags
- Track header dependencies for `dllentry.obj` and `enable.obj`

## Testing
- `dosbox-x -exit -fastlaunch -c "mount c /workspace/oemdisplay-tandy" -c "c:" -c "set PATH=%PATH%;C:\DDK\286\TOOLS" -c "set LIB=%LIB%;C:\DDK\286\LIB" -c "set INCLUDE=%INCLUDE%;C:\DDK\286\INC" -c "del TNDY16.DRV" -c "del TNDY16.MAP" -c "del *.OBJ" -c "del *.EXE" -c "del *.TXT" -c "BUILD" -c "exit"` *(fails: unresolved externals)*

------
https://chatgpt.com/codex/tasks/task_e_68c0aa0943e08325b015876654c615b5