### PR TITLE
Add DOSBox-X configuration and update build instructions

### DIFF
--- a/BUILDING.MD
+++ b/BUILDING.MD
@@ -11,6 +11,16 @@ This project targets 16-bit Windows using Microsoft C 6.0.
 
 ## Building and Packaging
 
+For a clean build run:
+
+```
+dosbox-x -no-console -conf dosbox-x.conf
+```
+
+The configuration mounts this repository, clears previous binaries, and
+executes `BUILD.BAT` with output redirected to `OUT.TXT`. Review
+`OUT.TXT` to confirm the build succeeded.
+
 1. Start DOSBox-X.
 2. Mount the repository as drive C: `MOUNT C <repo>`.
 3. Set the toolchain environment:

--- a/dosbox-x.conf
+++ b/dosbox-x.conf
@@ -1,0 +1,27 @@
+[sdl]
+output=default
+priority=highest,normal
+
+[dosbox]
+machine=tandy
+memsize=8
+
+[cpu]
+core=normal
+cputype=386
+cycles=fixed 3000
+
+[log]
+logfile=dosbox.log
+loglevel=debug
+
+[autoexec]
+@echo off
+mount C .
+C:
+PATH=C:\BIN;%PATH%
+SET LIB=C:\LIB
+SET INCLUDE=C:\INCLUDE
+DEL /Q BIN\*.EXE OBJ\*.OBJ
+BUILD.BAT > OUT.TXT
+EXIT


### PR DESCRIPTION
## Summary
- add `dosbox-x.conf` to configure SDL, Tandy machine, CPU, logging, and automated build steps
- document running `dosbox-x -no-console -conf dosbox-x.conf` for clean builds and checking `OUT.TXT`

## Testing
- `dosbox-x -no-console -conf dosbox-x.conf` *(fails: Bad command or filename - "NMAKE")*


------
https://chatgpt.com/codex/tasks/task_e_68c0d02c6fa48325924886aa3f9d1c22