### PR TITLE
docs: use supported DOSBox flag

### DIFF
--- a/BUILDING.MD
+++ b/BUILDING.MD
@@ -14,7 +14,7 @@ This project targets 16-bit Windows using Microsoft C 6.0.
 For a clean build run:
 
 ```
-dosbox-x -no-console -conf dosbox-x.conf
+dosbox-x -noconsole -conf dosbox-x.conf
 ```
 
 The configuration mounts this repository, clears previous binaries, and


### PR DESCRIPTION
## Summary
- replace deprecated `-no-console` with supported `-noconsole` in BUILDING.MD

## Testing
- `dosbox-x -noconsole -conf dosbox-x.conf` *(fails: XDG_RUNTIME_DIR is invalid or not set)*

------
https://chatgpt.com/codex/tasks/task_e_68c0ef0bb43c8325b67e2bd54bc6a6a4