### PR TITLE
Add developer guide and fix OEMSETUP.INF configuration

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,117 @@
+# CLAUDE.md
+
+This file provides guidance to Claude Code (claude.ai/code) when working with code in this repository.
+
+## Project Overview
+
+OEMDisplay-Tandy is a **Windows 3.x OEM display driver** for the Tandy 1000 series, enabling native TGA (Tandy Graphics Adapter) 320x200 16-color mode. This is a **16-bit real-mode** driver built with vintage DOS tooling — not a modern project.
+
+## Build System
+
+All compilation happens inside **DOSBox-X** using bundled tools in `BIN/`. You cannot build from a Linux shell.
+
+### Prerequisites
+```bash
+sudo apt-get install -y dosbox-x unix2dos file dos2unix
+```
+
+### Build Commands
+```bash
+# Automated build (recommended) — spawns DOSBox-X, runs 5-stage build
+build_driver.bat
+
+# Package for distribution (creates TNDY16.ZIP)
+makedisk.bat
+
+# Manual build inside DOSBox-X (stages 1-5, resumable)
+BLDTNDY.BAT 1   # Assemble core: TANDY, CURSORS, INQUIRE, SETMODE
+BLDTNDY.BAT 2   # Assemble: DISABLE, COLOR, BLKWHITE, CHKSTK, COLORINF
+BLDTNDY.BAT 3   # Assemble: CONTROL, FB, CHARWDTH, DITHER (-DLORES)
+BLDTNDY.BAT 4   # Assemble: DITHER (-DHIRES), SSWITCH, TGAVID, cursor, ENABLE, stubs
+BLDTNDY.BAT 5   # Link all OBJ files → TANDY16.DRV via LINK4
+```
+
+### Build Output
+- `TNDY16.DRV` — the driver binary (copied to project root on success)
+- `BUILD.LOG` — build log (check for errors)
+- `TNDY16.MAP` — linker map file (useful for debugging symbol issues)
+
+### No Automated CI
+Manual DOSBox-X builds are required. The GitHub Actions workflow (`release.yml`) only packages pre-built binaries.
+
+## Architecture
+
+### Toolchain
+- **Assembler:** MASM 5.10 (`BIN/MASM.EXE`)
+- **Linker:** LINK4.EXE — Windows 3.x Segmented Executable Linker (`BIN/LINK4.EXE`)
+- **C Compiler:** Microsoft C 6.0 (`BIN/CL.EXE`) — C89 only
+- **DDK headers:** `DDK/INC/` and `DDK/286/INC/` (cmacros.inc, gdidefs.inc, etc.)
+
+### Source Layout
+All driver source lives in `src/tandy16/`. The driver is a Windows DLL (`.DRV`) that exports 7 GDI entry points defined in `tandy16.def`:
+
+| Export | Ordinal | Source |
+|--------|---------|--------|
+| ENABLE (=TandyEnable) | @1 | ENABLE.ASM |
+| DISABLE (=TandyDisable) | @2 | DISABLE.ASM |
+| COLORINFO | @3 | COLORINF.ASM |
+| REALIZEOBJECT | @4 | stubs.asm |
+| BITBLT | @5 | stubs.asm |
+| OUTPUT | @6 | stubs.asm |
+| DEVICEMODE | @7 | SETMODE.ASM |
+
+### Key Modules
+- **TANDY.ASM** — Physical device structure (GDIINFO/PDEVICE)
+- **TGAVID.ASM / TGAVID.H** — Hardware abstraction: TGA detection, mode setting, plane info
+- **FB.ASM** — Framebuffer/shadow buffer operations
+- **SSWITCH.ASM** — Int 2Fh screen switching hook
+- **COLOR.ASM / COLORINF.ASM** — Palette realization, RGB color handling
+- **DITHER.ASM** — Compiled twice: once with `-DLORES`, once with `-DHIRES`
+- **CURSORS.ASM / cursor.asm** — Cursor rendering
+- **tandy16.def** — Module definition with exports and Windows API imports
+- **tandy16.lnk** — Linker response file (object file order matters)
+
+### Calling Convention
+All assembly uses **Pascal calling convention** (`?PLM=1`). This produces uppercase, undecorated symbol names. Mixing C convention (`?PLM=0`) causes L2029 linker errors — all modules must consistently use `?PLM=1`.
+
+The `cmacros.inc` macros (`sBegin`, `sEnd`, `cProc`, `cBegin`, `cEnd`) handle segment setup and procedure framing. These are required for Windows driver compatibility.
+
+## File Format Requirements
+
+- **Line endings:** CRLF (`\r\n`) is **mandatory** — MASM 5.10 fails on LF-only files. Use `unix2dos` if needed.
+- **Filenames:** 8.3 format, uppercase (e.g., `TANDY.ASM`, not `tandy.asm`).
+- **Encoding:** ASCII only, no UTF-8 BOM.
+
+## Coding Standards
+
+- **Assembly:** MASM 5.1 syntax, 8086 instruction set, Pascal calling convention
+- **C code:** Strictly C89 — no C99 or C++ features
+- **Indentation:** 4 spaces, no tabs
+- **Line length:** 80 columns max
+- **Integer types:** Use explicit-width types (`uint8_t`, `WORD`, `DWORD`)
+
+## Common Linker Errors
+
+| Error | Cause | Fix |
+|-------|-------|-----|
+| L2029 Unresolved External | Missing symbol or calling convention mismatch | Verify `?PLM=1` in all ASM files; check DEF exports |
+| L2023 Export Imported | Symbol exported by driver but also in LIBW.LIB | Use `/NOE` linker flag; rename export alias in DEF |
+| L2022 Export Undefined | DEF exports symbol not found in OBJ | Check `cProc` macro expansion; verify PUBLIC declaration |
+| Fixup Overflow | NEAR call across distant segments | Convert to FAR call or rearrange segments |
+
+## Testing
+
+No automated tests exist. Validation requires:
+1. Build driver (`build_driver.bat`)
+2. Check `BUILD.LOG` for errors
+3. Install `TNDY16.DRV` on a Windows 3.0/3.1 system (real or emulated)
+4. Run Windows Setup, select the Tandy driver, verify 320x200 16-color display
+
+## Current Development Status
+
+**Milestones 1-3 complete**: Driver builds, links, and packages successfully.
+
+**Remaining linker issues** (see `handoff.md` for details):
+- L2023: `Enable`/`Disable` export conflicts with LIBW.LIB
+- L2022: `DeviceMode`/`ColorInfo` symbol visibility issues
+- Unresolved: `_sum_RGB_colors_alt`, `COLOR_FORMAT` (likely missing from COLOR.ASM)

--- a/disk1/OEMSETUP.INF
+++ b/disk1/OEMSETUP.INF
@@ -1,64 +1,52 @@
+; OEMSETUP.INF -- Tandy 1000 Windows 3.0 Display Driver
+; ---------------------------------------------------------------
+; Install via Windows Setup: select "Other display (Requires disk
+; from OEM)" and provide the path to this disk.
+;
+; Based on the Microsoft Windows 3.x DDK sample OEMSETUP.INF.
+; See DDK Device Driver Adaptation Guide, Chapter 14.
+
 ; VERSION INFO
 ; ---------------------------------------------------------------
 ; This tells Setup that this is a 3.0 compatible OEM driver disk.
 
 [data]
-    Version   = "3.0"
+    Version = "3.0"
 
-; OEMSETUP.INF for the Tandy 1000 Windows 3.x display driver
+; DRIVER DISKS
+; ---------------------------------------------------------------
+; Setup prompts the user to "insert the:" followed by the disk name.
 
 [disks]
-1="Tandy 1000 Display Driver Disk",,0
+    a =., "Tandy 1000 Display Driver Disk"
+
 ; DISPLAY TYPES
 ; ---------------------------------------------------------------
-; Specify the complete list of display types, colors, and resolutions
-; available in this section.  Some tips...
+; Resolution triplet is "AspectRatio, LogPixelsX, LogPixelsY".
+; AspectRatio = LogPixelsX * 100 / LogPixelsY.
+; We use EGA-class values (133,96,72) as the closest standard
+; font resolution for the 320x200 display mode.
 ;
-; Profile:              This must be a unique identifier.
-;
-; Description:          No more than 47 characters!  Include all necessary info.
-;                       This description string should change slightly in new versions
-;                       of your driver disk.  Include a version id, and keep the rest
-;                       of the string the same, e.g. "ACME Z-1000 v1.1 640x480, 256 colors".
-;
-; VDD:                  Don't reference *vddvga!  This file uses "vddvga.386" instead,
-;                       which can be built using the Windows 3.0 DDK source files.
-;
-; NOTE:  Optional work sections are not supported by Windows 3.0 Setup!
-;        Windows 3.0 Setup cannot copy extra files or write to INI files.
-;        For this reason, the XGA, V7VGA, and TIGA drivers are not shown here.
+; Fields: profile = driver, description, resolution,
+;         286grabber, logocode, VDD, 386grabber, ega.sys, logodata
 
 [display]
-;profile = driver,         Description of driver,                           resolution,    286 grabber,    logo code,       VDD,            386grabber,   ega.sys,   logo data
-;hercules = b:hercules.drv, "Hercules Monochrome",                           "133,96,72",   b:hercules.2gr, a:herclogo.lgo,  b:vddherc.386,  b:herc.3gr,,             a:herclogo.rle
-
-; Tandy 1000 320x200 16-color TGA mode
-tndy16 = 1:tndy16.drv, "Tandy 1000 320x200 16 colors", "320,200,16",,, ,,
-
-[files]
-tndy16.drv,tndy16.drv,1
-
-
-
-; 386 GRABBER FONTS
-; ---------------------------------------------------------------
-; Setup will copy these fonts, sometimes called "old app fonts",
-; depending on the 386 grabber being used.  If you use your own
-; 386 grabber, then you should be sure to specify a section with
-; your grabber name.  You only need sections that correspond to
-; 386 grabber names in the [display] section.
-
-
+tndy16 = a:tndy16.drv, "Tandy 1000 320x200, 16 colors", "133,96,72",,,,,,
 
 ; SYSTEM FONTS
 ; ---------------------------------------------------------------
-; Fonts are installed according to the resolution of the display type selected.
-; Your OEMSETUP.INF file must have these sections, with all font resolution lines
-; appropriate for the listings in the [display] section.
+; Fonts are selected by matching the resolution string from the
+; [display] section. EGA-resolution fonts are the smallest standard
+; set and the best fit for the 320x200 display mode.
+;
+; If these font files are not on the driver disk, Windows Setup
+; will prompt for the original Windows installation disk.
 
-[TNDY16.DRV]
-320,200,16,1:VGASYS.FON,1:VGAFIX.FON,1:VGAOEM.FON
+[sysfonts]
+a:egasys.fon, "EGA (640x350) resolution System Font", "133,96,72"
 
-[setup]
-display.drv,tndy16.drv
+[fixedfonts]
+a:egafix.fon, "EGA (640x350) resolution Fixed System Font", "133,96,72"
 
+[oemfonts]
+a:egaoem.fon, "EGA (640x350) resolution Terminal Font (USA/Europe)", "133,96,72", 1

--- a/oemsetup.inf
+++ b/oemsetup.inf
@@ -1,64 +1,52 @@
+; OEMSETUP.INF -- Tandy 1000 Windows 3.0 Display Driver
+; ---------------------------------------------------------------
+; Install via Windows Setup: select "Other display (Requires disk
+; from OEM)" and provide the path to this disk.
+;
+; Based on the Microsoft Windows 3.x DDK sample OEMSETUP.INF.
+; See DDK Device Driver Adaptation Guide, Chapter 14.
+
 ; VERSION INFO
 ; ---------------------------------------------------------------
 ; This tells Setup that this is a 3.0 compatible OEM driver disk.
 
 [data]
-    Version   = "3.0"
+    Version = "3.0"
 
-; OEMSETUP.INF for the Tandy 1000 Windows 3.x display driver
+; DRIVER DISKS
+; ---------------------------------------------------------------
+; Setup prompts the user to "insert the:" followed by the disk name.
 
 [disks]
-1="Tandy 1000 Display Driver Disk",,0
+    a =., "Tandy 1000 Display Driver Disk"
+
 ; DISPLAY TYPES
 ; ---------------------------------------------------------------
-; Specify the complete list of display types, colors, and resolutions
-; available in this section.  Some tips...
+; Resolution triplet is "AspectRatio, LogPixelsX, LogPixelsY".
+; AspectRatio = LogPixelsX * 100 / LogPixelsY.
+; We use EGA-class values (133,96,72) as the closest standard
+; font resolution for the 320x200 display mode.
 ;
-; Profile:              This must be a unique identifier.
-;
-; Description:          No more than 47 characters!  Include all necessary info.
-;                       This description string should change slightly in new versions
-;                       of your driver disk.  Include a version id, and keep the rest
-;                       of the string the same, e.g. "ACME Z-1000 v1.1 640x480, 256 colors".
-;
-; VDD:                  Don't reference *vddvga!  This file uses "vddvga.386" instead,
-;                       which can be built using the Windows 3.0 DDK source files.
-;
-; NOTE:  Optional work sections are not supported by Windows 3.0 Setup!
-;        Windows 3.0 Setup cannot copy extra files or write to INI files.
-;        For this reason, the XGA, V7VGA, and TIGA drivers are not shown here.
+; Fields: profile = driver, description, resolution,
+;         286grabber, logocode, VDD, 386grabber, ega.sys, logodata
 
 [display]
-;profile = driver,         Description of driver,                           resolution,    286 grabber,    logo code,       VDD,            386grabber,   ega.sys,   logo data
-;hercules = b:hercules.drv, "Hercules Monochrome",                           "133,96,72",   b:hercules.2gr, a:herclogo.lgo,  b:vddherc.386,  b:herc.3gr,,             a:herclogo.rle
-
-; Tandy 1000 320x200 16-color TGA mode
-tndy16 = 1:tndy16.drv, "Tandy 1000 320x200 16 colors", "320,200,16",,, ,,
-
-[files]
-tndy16.drv,tndy16.drv,1
-
-
-
-; 386 GRABBER FONTS
-; ---------------------------------------------------------------
-; Setup will copy these fonts, sometimes called "old app fonts",
-; depending on the 386 grabber being used.  If you use your own
-; 386 grabber, then you should be sure to specify a section with
-; your grabber name.  You only need sections that correspond to
-; 386 grabber names in the [display] section.
-
-
+tndy16 = a:tndy16.drv, "Tandy 1000 320x200, 16 colors", "133,96,72",,,,,,
 
 ; SYSTEM FONTS
 ; ---------------------------------------------------------------
-; Fonts are installed according to the resolution of the display type selected.
-; Your OEMSETUP.INF file must have these sections, with all font resolution lines
-; appropriate for the listings in the [display] section.
+; Fonts are selected by matching the resolution string from the
+; [display] section. EGA-resolution fonts are the smallest standard
+; set and the best fit for the 320x200 display mode.
+;
+; If these font files are not on the driver disk, Windows Setup
+; will prompt for the original Windows installation disk.
 
-[TNDY16.DRV]
-320,200,16,1:VGASYS.FON,1:VGAFIX.FON,1:VGAOEM.FON
+[sysfonts]
+a:egasys.fon, "EGA (640x350) resolution System Font", "133,96,72"
 
-[setup]
-display.drv,tndy16.drv
+[fixedfonts]
+a:egafix.fon, "EGA (640x350) resolution Fixed System Font", "133,96,72"
 
+[oemfonts]
+a:egaoem.fon, "EGA (640x350) resolution Terminal Font (USA/Europe)", "133,96,72", 1


### PR DESCRIPTION
## Summary

This PR adds comprehensive developer documentation and corrects the OEMSETUP.INF setup configuration file to properly support Windows 3.0 OEM driver installation.

## Changes

### Documentation
- **Added CLAUDE.md**: Comprehensive developer guide for working with this vintage Windows 3.x driver project, including:
  - Project overview and build system instructions
  - Architecture and toolchain details (MASM 5.10, LINK4, Microsoft C 6.0)
  - Source layout and module descriptions
  - File format requirements (CRLF line endings, 8.3 filenames, ASCII encoding)
  - Coding standards for assembly and C code
  - Common linker errors and troubleshooting
  - Testing procedures and current development status

### Configuration
- **Fixed OEMSETUP.INF** (both root and disk1/ versions):
  - Corrected disk reference from `1=` to `a =.` (proper Windows 3.0 Setup syntax)
  - Fixed display profile to use correct disk prefix: `a:tndy16.drv` instead of `1:tndy16.drv`
  - Corrected resolution triplet from `"320,200,16"` to `"133,96,72"` (AspectRatio, LogPixelsX, LogPixelsY format per DDK spec)
  - Replaced invalid `[TNDY16.DRV]` section with proper `[sysfonts]`, `[fixedfonts]`, and `[oemfonts]` sections
  - Updated font references from VGA fonts to EGA fonts (egasys.fon, egafix.fon, egaoem.fon) with correct resolution metadata
  - Removed obsolete `[files]` and `[setup]` sections
  - Added detailed comments explaining resolution calculation and font selection logic

## Implementation Details

The OEMSETUP.INF corrections align with the Microsoft Windows 3.x DDK Device Driver Adaptation Guide (Chapter 14) and ensure proper driver installation via Windows Setup's "Other display (Requires disk from OEM)" option. The resolution triplet change reflects the actual 320x200 display mode mapped to EGA-class font resolution for compatibility with standard Windows font sets.

The CLAUDE.md guide documents the project's unique requirements as a 16-bit real-mode DOS driver built with vintage tooling, providing essential context for contributors working with MASM 5.10, Pascal calling conventions, and the Windows 3.x driver architecture.

https://claude.ai/code/session_011Aakr87e7eiQGoh4PGYLHC